### PR TITLE
Fix an issue with TextSlide and narrow windows.

### DIFF
--- a/src/Slide/TextSlide.php
+++ b/src/Slide/TextSlide.php
@@ -23,7 +23,7 @@ class TextSlide extends Slide
         $height = count($lines);
         $width = max(array_map('mb_strlen', $lines));
         $terminal = new Terminal();
-        $paddingX = (int)floor(($terminal->getWidth() - $width) / 2);
+        $paddingX = max((int)floor(($terminal->getWidth() - $width) / 2), 0);
         $paddingY = max((int)floor(($terminal->getHeight() - $height) / 2), 0);
 
         $this->getOutput()->write(str_repeat(PHP_EOL, $paddingY));


### PR DESCRIPTION
When the window is narrower than the text, $paddingX ends up less than 0, causing str_repeat() to issue a warning, and ending the presentation.

I encountered this with the sample presentation, and a window set at 100x30.